### PR TITLE
Fix a bug in parsing 005 arguments

### DIFF
--- a/zirc/event.py
+++ b/zirc/event.py
@@ -19,7 +19,10 @@ class Event(object):
             self.type, args = raw.split(" ", 1)
             self.source = self.target = None
         self.arguments = []
-        args = args.split(":", 1)
+        if args.startswith(":"):
+            args = args.split(":", 1)
+        else:
+            args = args.split(" :", 1)
         for arg in args[0].split(" "):
             if len(arg) > 0:
                 self.arguments.append(arg)


### PR DESCRIPTION
This fixes a bug which causes 005 arguments to be split in the wrong place and therefore parsed incorrectly
Example:

```
arguments: ['TARGMAX=NAMES', '1,LIST:1,KICK:1,WHOIS:1,PRIVMSG:4,NOTICE:4,ACCEPT:,MONITOR: EXTBAN=$,&acjmorxz| CLIENTVER=3.0 :are supported by this server']
```
