### PR TITLE
Fix a NICK handling bug in event

### DIFF
--- a/zirc/event.py
+++ b/zirc/event.py
@@ -18,6 +18,9 @@ class Event(object):
         else:
             self.type, args = raw.split(" ", 1)
             self.source = self.target = None
+        if self.target:
+            if self.target.startswith(":"): # n!u@h NICK :nuh
+                self.target = self.target.replace(":", "", 1)
         self.arguments = []
         if args.startswith(":"):
             args = args.split(":", 1)


### PR DESCRIPTION
Due to the NICK syntax (`nick!user@host NICK :newnick`), `event.target` would be set to `:newnick`. This change will check if event.target starts with a `:` and if so, will remove it.
