### PR TITLE
Fix some linter errors (Pylint, Pyflakes)

### DIFF
--- a/zirc/client.py
+++ b/zirc/client.py
@@ -2,12 +2,9 @@ from .connection import Socket
 from .event import Event
 from .flood import floodProtect
 from .loop import EventLoop
-from .errors import *
+from .errors import NoSocket, NoConfig
 from . import util
 from .wrappers import connection_wrapper
-
-from base64 import b64encode
-import sys,time
 
 class Client(object):
     listeners = []

--- a/zirc/connection.py
+++ b/zirc/connection.py
@@ -19,7 +19,8 @@ class Socket(object):
         self.wrapper = wrapper
     def connect(self, socket_address):
         self.sock = self.wrapper(self.sock)
-        self.bind_address and sock.bind(self.bind_address)
+        if self.bind_address:
+            self.sock.bind(self.bind_address)
         self.sock.connect(socket_address)
         
         return self.sock

--- a/zirc/ext/fifo.py
+++ b/zirc/ext/fifo.py
@@ -3,9 +3,9 @@ import os, threading
 def fifo_while(send_function, name):
     if not os.path.exists(name):
         os.mkfifo(name)
-    with open(name, "r") as file:
+    with open(name, "r") as f:
         while True:
-            line = file.readline()[:-1]
+            line = f.readline()[:-1]
             if len(line) > 0:
                 send_function(line)
                 

--- a/zirc/ext/proxy.py
+++ b/zirc/ext/proxy.py
@@ -1,4 +1,4 @@
-import socks,socket
+import socks, socket
 SOCKS5 = socks.SOCKS5
 SOCKS4 = socks.SOCKS4
 HTTP = socks.HTTP

--- a/zirc/flood.py
+++ b/zirc/flood.py
@@ -13,7 +13,7 @@ class floodProtect(object):
                 connection = self.irc_queue[0][0]
                 raw = self.irc_queue[0][1]
                 self.irc_queue.pop(0)
-            except:
+            except Exception:
                 self.irc_queue_running = False
                 break
             connection.send(raw)

--- a/zirc/test.py
+++ b/zirc/test.py
@@ -20,12 +20,12 @@ class TestCase(object):
                 print("Attempting to run on_all...")
                 util.function_argument_call(self.on_all, args)()
 
-            text_type_func_name = "on_"+event.text_type.lower()
+            text_type_func_name = "on_" + event.text_type.lower()
             if hasattr(self, text_type_func_name):
                 print("Attempting to run {0}".format(text_type_func_name))
                 util.function_argument_call(getattr(self, text_type_func_name), args)()
 
-            raw_type_func_name = "on_"+event.type.lower()
+            raw_type_func_name = "on_" + event.type.lower()
             if raw_type_func_name != text_type_func_name:
                 if hasattr(self, raw_type_func_name):
                     print("Attempting to run {0}".format(raw_type_func_name))

--- a/zirc/util/bucket.py
+++ b/zirc/util/bucket.py
@@ -1,3 +1,5 @@
+from time import time
+
 class TokenBucket(object):
     """An implementation of the token bucket algorithm.
 

--- a/zirc/wrappers.py
+++ b/zirc/wrappers.py
@@ -1,9 +1,12 @@
+from time import time
+
 class connection_wrapper(object):
     def __init__(self, irc):
         self.send = irc.send
         self.reply = irc.reply
         self.msg = irc.privmsg
         self.privmsg = irc.privmsg
+
     def ping(self):
         self.send("PING :{}".format(str(int(time()))).encode('utf-8'))
 
@@ -20,10 +23,10 @@ class connection_wrapper(object):
         self.send("INVITE {0} {1}".format(user, chan))
 
     def action(self, channel, message):
-        self.sendmsg(channel,"\x01ACTION {0}\x01".format(message))
+        self.sendmsg(channel, "\x01ACTION {0}\x01".format(message))
 
-    def kick(self,channel, user, message):
-        user = user.replace(" ","").replace(":","")
+    def kick(self, channel, user, message):
+        user = user.replace(" ", "").replace(":", "")
         self.send("KICK {0} {1} :{2}".format(channel, user, message))
 
     def op(self, channel, nick):
@@ -52,12 +55,12 @@ class connection_wrapper(object):
 
     def mode(self, channel, nick, mode):
         self.send("MODE {0} {1} {2}".format(channel, mode, nick))
-        
+
     def notice(self, user, message):
         self.send("NOTICE {0} :{1}".format(user, message))
 
     def quit(self, message=""):
         self.send("QUIT : {0}".format(message))
-    
+
     def ctcp(self, user, message):
         self.send("PRIVMSG {0} :\x01{1}\x01\x01".format(user, message))


### PR DESCRIPTION
## _**Linter warnings fixed:**_
- Remove some unused imports
- Fix 'Expression is assigned to nothing' warning
- Don't redefine built-ins
- Don't use bare excepts
- Fix undefined variables
- Remove trailing whitespace
- Add some missing new-lines
- Add spaces around operators
- Remove some unused imports

From my observations it increases speed somewhat, when comparing the run times in TravisCI to previous ones
